### PR TITLE
Implemented get_assertions for cvc5 and z3

### DIFF
--- a/bitwuzla/include/bitwuzla_solver.h
+++ b/bitwuzla/include/bitwuzla_solver.h
@@ -86,6 +86,7 @@ class BzlaSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/bitwuzla/src/bitwuzla_solver.cpp
+++ b/bitwuzla/src/bitwuzla_solver.cpp
@@ -197,6 +197,12 @@ UnorderedTermMap BzlaSolver::get_array_values(const Term & arr,
       "Bitwuzla backend doesn't support get_array_values yet");
 }
 
+void BzlaSolver::get_assertions(TermVec & out) {
+  throw NotImplementedException(
+      "Bitwuzla backend doesn't support get_assertions yet");
+}
+
+
 void BzlaSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   size_t size;

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -67,6 +67,7 @@ class BoolectorSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -478,6 +478,11 @@ UnorderedTermMap BoolectorSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
+void BoolectorSolver::get_assertions(TermVec & out)
+{
+  throw NotImplementedException("get_assertions not supported in Boolector");
+}
+
 void BoolectorSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);

--- a/cvc5/include/cvc5_solver.h
+++ b/cvc5/include/cvc5_solver.h
@@ -64,6 +64,7 @@ class Cvc5Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/cvc5/src/cvc5_solver.cpp
+++ b/cvc5/src/cvc5_solver.cpp
@@ -433,6 +433,22 @@ UnorderedTermMap Cvc5Solver::get_array_values(const Term & arr,
   }
 }
 
+void Cvc5Solver::get_assertions(TermVec & out) 
+{
+  try
+  {
+    for (auto cterm : solver.getAssertions())
+    {
+      out.push_back(std::make_shared<Cvc5Term>(cterm));
+    }
+  }
+  catch(const std::exception& e)
+  {
+    throw InternalSolverException(e.what());
+  }
+  
+}
+
 void Cvc5Solver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   Term f;

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -65,6 +65,7 @@ class GenericSolver : public AbsSmtSolver
   Term get_selector(const Sort & s,
                     std::string con,
                     std::string name) const override;
+  void get_assertions(TermVec & out) override;
 
   /***************************************************************/
   /* methods from AbsSmtSolver that are implemented              */

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -74,6 +74,7 @@ class LoggingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   // Will probably remove this eventually
   // For now, need to clear the hash table

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -52,6 +52,7 @@ class PrintingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   void reset() override;
   void set_opt(const std::string option, const std::string value) override;

--- a/include/smtlib_utils.h
+++ b/include/smtlib_utils.h
@@ -27,6 +27,7 @@ const std::string ASSERT_STR = "assert";
 const std::string CHECK_SAT_STR = "check-sat";
 const std::string CHECK_SAT_ASSUMING_STR = "check-sat-assuming";
 const std::string GET_VALUE_STR = "get-value";
+const std::string GET_ASSERTIONS_STR = "get-assertions";
 const std::string GET_UNSAT_ASSUMPTIONS_STR = "get-unsat-assumptions";
 const std::string PUSH_STR = "push";
 const std::string POP_STR = "pop";

--- a/include/solver.h
+++ b/include/solver.h
@@ -113,6 +113,12 @@ class AbsSmtSolver
   virtual UnorderedTermMap get_array_values(const Term & arr,
                                             Term & out_const_base) const = 0;
 
+  /** This function will populate the 'assertions' TermVec with the current set
+   *  of all asserted formulas in the solver.
+   *  SMTLIB: (get-assertions)
+   */
+  virtual void get_assertions(TermVec & assertions) = 0;
+
   /** After a call to check_sat_assuming that returns an unsatisfiable result
    *  this function will populate the 'out' UnorderedTermSet with a subset
    *  of the assumption literals that are sufficient to make the assertions

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -87,6 +87,7 @@ class MsatSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -369,6 +369,12 @@ UnorderedTermMap MsatSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
+void MsatSolver::get_assertions(TermVec & out)
+{
+  throw NotImplementedException(
+      "get_assertions not yet supported for MathSAT.");
+}
+
 void MsatSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   initialize_env();

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -1116,6 +1116,12 @@ string GenericSolver::strip_value_from_result(string result) const
   return strip;
 }
 
+void GenericSolver::get_assertions(TermVec & out) 
+{
+  throw NotImplementedException(
+      "Generic solver does not yet support get-assertions");
+}
+
 void GenericSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   // run get-unsat-assumptions command

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -480,6 +480,11 @@ Term LoggingSolver::get_value(const Term & t) const
   return res;
 }
 
+void LoggingSolver::get_assertions(TermVec & out) 
+{
+  wrapped_solver->get_assertions(out);
+}
+
 void LoggingSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   UnorderedTermSet underlying_core;

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -196,6 +196,12 @@ Term PrintingSolver::get_value(const Term & t) const
   return wrapped_solver->get_value(t);
 }
 
+void PrintingSolver::get_assertions(TermVec & out)
+{
+  (*out_stream) << "(" << GET_ASSERTIONS_STR << ")" << end;
+  wrapped_solver->get_assertions(out);
+}
+
 void PrintingSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   (*out_stream) << "(" << GET_UNSAT_ASSUMPTIONS_STR << ")" << endl;

--- a/tests/cvc5/CMakeLists.txt
+++ b/tests/cvc5/CMakeLists.txt
@@ -9,6 +9,7 @@ endmacro()
 # TODO move old tests to Google Test infrastructure
 switch_add_cvc5_test(cvc5-arrays)
 switch_add_cvc5_test(cvc5-data-structures)
+switch_add_cvc5_test(cvc5-get-assertions)
 switch_add_cvc5_test(cvc5-indexed-op-tests)
 switch_add_cvc5_test(cvc5-int-arithmetic)
 switch_add_cvc5_test(cvc5_test)

--- a/tests/cvc5/cvc5-get-assertions.cpp
+++ b/tests/cvc5/cvc5-get-assertions.cpp
@@ -1,0 +1,67 @@
+/*********************                                                        */
+/*! \file cvc5_test.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief
+**
+**
+**/
+
+#include <iostream>
+
+#include "cvc5_factory.h"
+#include "smt.h"
+#include "assert.h"
+
+// after full installation
+// #include "smt-switch/cvc5_factory.h"
+// #include "smt-switch/smt.h"
+
+using namespace std;
+using namespace smt;
+
+int main()
+{
+  SmtSolver s = Cvc5SolverFactory::create(false);
+
+  Term a = s->make_symbol("a", s->make_sort(BOOL));
+  Term b = s->make_symbol("b", s->make_sort(BOOL));
+  Term c = s->make_symbol("c", s->make_sort(BOOL));
+
+  s->push();
+
+  Term assertion1 = s->make_term(Or, a, b);
+  s->assert_formula(assertion1);
+
+  TermVec vec;
+  s->get_assertions(vec);
+  assert(vec.size() == 1);
+  assert(vec[0]->to_string() == "(or a b)");
+
+  Term assertion2 = s->make_term(And, s->make_term(Not,c), s->make_term(Or,a,b));
+  s->assert_formula(assertion2);
+  vec.clear();
+  s->get_assertions(vec);
+  assert(vec.size() == 2);
+  assert(vec[0]->to_string() == "(or a b)");
+  assert(vec[1]->to_string() == "(and (not c) (or a b))");
+
+  s->pop();
+
+  Term assertion3 = s->make_term(And,s->make_term(And,a,b),c);
+  s->assert_formula(assertion3);
+  vec.clear();
+  s->get_assertions(vec);
+  assert(vec.size() == 1);
+  assert(vec[0]->to_string() == "(and (and a b) c)");
+
+  return 0;
+}
+

--- a/tests/z3/CMakeLists.txt
+++ b/tests/z3/CMakeLists.txt
@@ -9,3 +9,4 @@ endmacro()
 # TODO move old tests to Google Test infrastructure
 switch_add_z3_test(z3_test)
 switch_add_z3_test(z3_full)
+switch_add_z3_test(z3_get_assertions)

--- a/tests/z3/z3_get_assertions.cpp
+++ b/tests/z3/z3_get_assertions.cpp
@@ -1,0 +1,67 @@
+/*********************                                                        */
+/*! \file cvc5_test.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief
+**
+**
+**/
+
+#include <iostream>
+
+#include "z3_factory.h"
+#include "smt.h"
+#include "assert.h"
+
+// after full installation
+// #include "smt-switch/cvc5_factory.h"
+// #include "smt-switch/smt.h"
+
+using namespace std;
+using namespace smt;
+
+int main()
+{
+  SmtSolver s = Z3SolverFactory::create(false);
+
+  Term a = s->make_symbol("a", s->make_sort(BOOL));
+  Term b = s->make_symbol("b", s->make_sort(BOOL));
+  Term c = s->make_symbol("c", s->make_sort(BOOL));
+
+  s->push();
+
+  Term assertion1 = s->make_term(Or, a, b);
+  s->assert_formula(assertion1);
+
+  TermVec vec;
+  s->get_assertions(vec);
+  assert(vec.size() == 1);
+  assert(vec[0]->to_string() == "(or a b)");
+
+  Term assertion2 = s->make_term(And, s->make_term(Not,c), s->make_term(Or,a,b));
+  s->assert_formula(assertion2);
+  vec.clear();
+  s->get_assertions(vec);
+  assert(vec.size() == 2);
+  assert(vec[0]->to_string() == "(or a b)");
+  assert(vec[1]->to_string() == "(and (not c) (or a b))");
+
+  s->pop();
+
+  Term assertion3 = s->make_term(And,s->make_term(And,a,b),c);
+  s->assert_formula(assertion3);
+  vec.clear();
+  s->get_assertions(vec);
+  assert(vec.size() == 1);
+  assert(vec[0]->to_string() == "(and (and a b) c)");
+
+  return 0;
+}
+

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -79,6 +79,7 @@ class Yices2Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -448,6 +448,13 @@ UnorderedTermMap Yices2Solver::get_array_values(const Term & arr,
       "particular select of the array.");
 }
 
+void Yices2Solver::get_assertions(TermVec & out)
+{
+  throw NotImplementedException(
+      "get_assertions not yet supported for Yices."
+  );
+}
+
 void Yices2Solver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   term_vector_t ycore;

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -60,6 +60,7 @@ class Z3Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
+  void get_assertions(TermVec & out) override;
   void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -492,6 +492,18 @@ UnorderedTermMap Z3Solver::get_array_values(const Term & arr,
       "Get array values not implemented for Z3 backend.");
 }
 
+void Z3Solver::get_assertions(TermVec & out)
+{
+  Z3_ast_vector vec = Z3_solver_get_assertions(ctx,slv);
+
+  for (size_t i = 0; i < Z3_ast_vector_size(ctx,vec); i++) 
+  {
+    z3::expr t = to_expr(ctx,Z3_ast_vector_get(ctx,vec,i));
+    Term t_term = std::make_shared<Z3Term>(t,ctx);
+    out.push_back(t_term);
+  }
+}
+
 void Z3Solver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   // in smt-switch, should throw exception if last query


### PR DESCRIPTION
Added get_assertions function in smt-switch, implemented for cvc5 and z3 only.